### PR TITLE
Correct feed welcome test

### DIFF
--- a/__test__/feed.test.js
+++ b/__test__/feed.test.js
@@ -9,7 +9,7 @@ describe("<Feed />", () => {
         const result = renderer.getRenderOutput();
         expect(result.type).toBe('div');
         expect(result.props.children).toEqual([
-           "Welcome to the feed for...",  "Makers Academy"
+           "Welcome to the feed for: ",  "Makers Academy"
         ])
     })
 })


### PR DESCRIPTION
A small tweak to fix a failing test. The wrong string was given for the feed welcome message.