### PR TITLE
Add test for catch block

### DIFF
--- a/__test__/socket.test.js
+++ b/__test__/socket.test.js
@@ -36,6 +36,10 @@ describe("Socket", () => {
       expect(eeMock.emit.mock.calls[1][0]).toBe('message name');
       expect(eeMock.emit.mock.calls[1][1]).toBe('message data');
     });
+    test("catches error when parsing invalid response message", () => {
+      testSocket.message("bad response");
+      expect(eeMock.emit.mock.calls[3][0]).toBe('error');
+    })
   });
   describe("#on", () => {
     test("calls event handler with correct message", () => {


### PR DESCRIPTION
I realised the 'catch' block was missing a test, so I added one to ensure we were handling bad responses. `socket.js` now has 100% coverage.